### PR TITLE
Add schema version

### DIFF
--- a/schemas/hpc-job-scheduler.md
+++ b/schemas/hpc-job-scheduler.md
@@ -1,4 +1,4 @@
-# HPC Job Scheduler Event Schema
+# HPC Job Scheduler Event Schema - Version 1
 
 NOTE: Work in Progress!
 
@@ -15,7 +15,7 @@ The columns for "Slurm" and "Flux" represent the field in that data set which is
 
 | **Field Name**           | **Data Type** | **Field Explanation**                                                                                         | **Slurm**       | **Flux**         |
 | ------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------- | --------------- | ---------------- |
-| schema.version           | integer       | The version of this schema that the log aligns with                                                           | 1               | 1                |
+| schema.version           | integer       | The version of this schema that the log aligns with                                                           | version         | version          |
 | event.dataset\*          | keyword       | Name of the dataset "slurm.joblog"                                                                            | "slurm.joblog"  | "flux.joblog"    |
 | job.id                   | keyword       | Scheduler managed identifier of the job                                                                       | JobId           | id               |
 | user.name\*              | keyword       | User name of who submitted the job                                                                            | UserId          | username         |


### PR DESCRIPTION
The joblog schema has had some minor updates recently, but doesn't have schema version to keep track of those changes. This MR adds `schema.version`, which will be included in each log going forward and will make it possible to filter logs based on schema version.